### PR TITLE
RD-15036  setOnConversionDataReceived Crash with Cocos2dx 3.17

### DIFF
--- a/Classes/AppsFlyer/AppsFlyerProxyX.cpp
+++ b/Classes/AppsFlyer/AppsFlyerProxyX.cpp
@@ -122,6 +122,8 @@ cocos2d::ValueMap getMapForCallback(JNIEnv *env, jobject attributionObject) {
 
         map[std::string(c_string_key)] = c_string_value;
     }
+
+    return map;
 }
 
 

--- a/Classes/AppsFlyer/AppsFlyerXAndroid.cpp
+++ b/Classes/AppsFlyer/AppsFlyerXAndroid.cpp
@@ -429,7 +429,7 @@ void AppsFlyerXAndroid::validateAndTrackInAppPurchase(const std::string &publicK
                                                                      "Ljava/lang/String;"
                                                                      "Ljava/lang/String;"
                                                                      "Ljava/lang/String;"
-                                                                     "Ljava/util/HashMap;)V");
+                                                                     "Ljava/util/Map;)V");
 
         jniGetInstance.env->CallVoidMethod(afInstance, methodId, jContext, jPublicKey, jSignature,
                                            jPurchaseData, jPrice, jCurrency, hashMapObj);


### PR DESCRIPTION
- Fixed setOnConversionDataReceived Crash with Cocos2dx 3.17
- Changed "validateAndTrackInAppPurchase" native signature (HashMap -> Map)